### PR TITLE
Standardize console width

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,23 @@ class CreateUserCommandTest extends TestCase
     }
 }
 ```
+
+## Standardize Terminal Width
+
+Under different terminal environments (ie Windows, Linux, Github Actions) the default
+terminal width can be calculated differently. Since certain Symfony output helpers
+use this to wrap long lines this can lead to output assertions failing in different
+environments. It is recommended to standardize the terminal width by setting the
+`COLUMNS` environment variable for your test suite:
+
+```xml
+<!-- phpunit.xml -->
+
+<phpunit>
+    <!-- ... -->
+    <php>
+        <env name="COLUMNS" value="120" />
+    </php>
+    <!-- ... -->
+</phpunit>
+```

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <ini name="error_reporting" value="-1" />
         <server name="KERNEL_CLASS" value="Zenstruck\Console\Test\Tests\Fixture\Kernel" />
         <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="COLUMNS" value="120" />
     </php>
 
     <testsuites>

--- a/tests/Fixture/FixtureCommand.php
+++ b/tests/Fixture/FixtureCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -58,6 +59,8 @@ final class FixtureCommand extends Command
         foreach ($input->getOption('opt3') as $value) {
             $output->writeln("opt3 value: {$value}");
         }
+
+        (new SymfonyStyle($input, $output))->success('Long link: https://github.com/zenstruck/console-test/blob/997ee1f66743342ffd9cd00a77613ebfa2efd2b8/src/CommandResult.php');
 
         return (int) $input->getOption('code');
     }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -173,4 +173,15 @@ final class FunctionalTest extends KernelTestCase
             ->assertOutputNotContains('kbond')
         ;
     }
+
+    /**
+     * @test
+     */
+    public function terminal_width_is_standardized(): void
+    {
+        $this->executeConsoleCommand('fixture:command')
+            ->assertOutputContains(' [OK] Long link:                                                                                                        ')
+            ->assertOutputContains('      https://github.com/zenstruck/console-test/blob/997ee1f66743342ffd9cd00a77613ebfa2efd2b8/src/CommandResult.php     ')
+        ;
+    }
 }

--- a/tests/UnitTest.php
+++ b/tests/UnitTest.php
@@ -130,4 +130,16 @@ final class UnitTest extends TestCase
             ->assertOutputNotContains('kbond')
         ;
     }
+
+    /**
+     * @test
+     */
+    public function terminal_width_is_standardized(): void
+    {
+        TestCommand::for(new FixtureCommand())
+            ->execute()
+            ->assertOutputContains(' [OK] Long link:                                                                                                        ')
+            ->assertOutputContains('      https://github.com/zenstruck/console-test/blob/997ee1f66743342ffd9cd00a77613ebfa2efd2b8/src/CommandResult.php     ')
+        ;
+    }
 }


### PR DESCRIPTION
Currently, depending on your environment, the console width may be different, leading to tests asserting console out to fail.