### PR TITLE
Run commands via application

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,9 +10,10 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <server name="KERNEL_CLASS" value="Zenstruck\Console\Test\Tests\Fixture\Kernel" />
-        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="KERNEL_CLASS" value="Zenstruck\Console\Test\Tests\Fixture\Kernel" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
         <env name="COLUMNS" value="120" />
+        <env name="SHELL_VERBOSITY" value="-1"/>
     </php>
 
     <testsuites>

--- a/src/TestInput.php
+++ b/src/TestInput.php
@@ -16,7 +16,7 @@ final class TestInput extends StringInput
     {
         parent::__construct($input);
 
-        $this->setInteractive(false);
+        parent::setInteractive(false);
 
         if ($inputs) {
             $stream = \fopen('php://memory', 'r+', false);
@@ -28,12 +28,17 @@ final class TestInput extends StringInput
             \rewind($stream);
 
             $this->setStream($stream);
-            $this->setInteractive(true);
+            parent::setInteractive(true);
         }
 
         if (true === $this->hasParameterOption(['--no-interaction', '-n'], true)) {
-            $this->setInteractive(false);
+            parent::setInteractive(false);
         }
+    }
+
+    public function setInteractive($interactive): void
+    {
+        // noop, prevent Application from setting this value
     }
 
     public function isDecorated(): bool

--- a/src/TestOutput.php
+++ b/src/TestOutput.php
@@ -48,6 +48,16 @@ final class TestOutput extends StreamOutput implements ConsoleOutputInterface
         return new ConsoleSectionOutput($this->getStream(), $this->sections, $this->getVerbosity(), $this->isDecorated(), $this->getFormatter());
     }
 
+    public function setDecorated($decorated): void
+    {
+        // noop, prevent Application from setting this value
+    }
+
+    public function setVerbosity($level): void
+    {
+        // noop, prevent Application from setting this value
+    }
+
     public function getDisplay(): string
     {
         \rewind($this->getStream());


### PR DESCRIPTION
This allows command events to be fired.

Some possible future features:
- enable exception catching (`TestCommand::catchExceptions(): self`)
- disable running commands through the application - there could be unforeseen consequences of this change (`TestCommand::isolate(): self`)