### PR TITLE
Allow falsy values to be passed to addOption and to the command execu…

### DIFF
--- a/src/TestCommand.php
+++ b/src/TestCommand.php
@@ -89,7 +89,7 @@ final class TestCommand
         foreach ((array) $value as $item) {
             $this->cli .= " {$name}";
 
-            if ($item) {
+            if (null !== $item) {
                 $this->cli .= \sprintf('="%s"', $item);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/zenstruck/console-test/issues/22

Allows to pass falsy values through `addOption` to the command execution.